### PR TITLE
Darell/dev 6133/modify update suggestion terms script

### DIFF
--- a/suggestion-terms/bin/update_suggestion_terms/update_suggestion_terms.go
+++ b/suggestion-terms/bin/update_suggestion_terms/update_suggestion_terms.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	hostPtr := flag.String("host", "http://localhost", "solr host")
 	portPtr := flag.Int("port", 8983, "solr port")
-	sourcePtr := flag.String("source", "product_source", "Source colllection to facet terms from.")
+	sourcePtr := flag.String("source", "product_source", "Source collection to facet terms from.")
 	targetPtr := flag.String("target", "suggestion_terms", "Target collection to update terms on.")
 	fqPtr := flag.String("fq", "django_ct:brands.brand", "'fq' param for facet query.")
 	facetFieldPtr := flag.String("facetfield", "pseudotiers_ss", "Field to facet on")

--- a/suggestion-terms/suggestion_terms.go
+++ b/suggestion-terms/suggestion_terms.go
@@ -97,6 +97,7 @@ func NewFacetQuery(fq []string, facetField []string) *solr.Query {
 			"facet.field": facetField,
 			"facet":       []string{"true"},
 			"facet.limit": []string{"-1"},
+			"facet.mincount": []string{"1"},
 		},
 	}
 }

--- a/suggestion-terms/suggestion_terms_test.go
+++ b/suggestion-terms/suggestion_terms_test.go
@@ -40,6 +40,17 @@ func TestNewSuggestionTerm(t *testing.T) {
 			ExpectedWeightField:  "brand_count_i",
 			ExpectedSuggestField: "suggest_s",
 		},
+		TestCase{
+			Got: NewSuggestionTerm(
+				"name_s",
+				solr.FacetCount{Value: "duravit", Count: 1},
+				"",
+				"",
+			),
+			ExpectedValue:	"duravit",
+		    ExpectedWeightField:  DefaultWeightField,
+		    ExpectedSuggestField: DefaultSuggestField,
+		},
 	}
 	for _, tc := range testCases {
 		if tc.Got.Value != tc.ExpectedValue {
@@ -85,6 +96,15 @@ func TestDocumentID(t *testing.T) {
 			),
 			Expected: "product_type_ent_ss.emergency lights",
 		},
+		TestCase{
+		Got: *NewSuggestionTerm(
+			"name_s",
+			solr.FacetCount{Value: "duravit", Count: 1},
+			"count_i",
+			"text",
+		),
+		Expected: "name_s.duravit",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -123,6 +143,15 @@ func TestNewDocument(t *testing.T) {
 				Fields: map[string]interface{}{
 					"id":     "product_type_ent_ss.wood doors",
 					"term_s": "wood doors",
+				},
+			},
+		},
+		TestCase{
+			Got: *NewSuggestionTerm("name_s", solr.FacetCount{Value: "duravit", Count: 1}, "", ""),
+			Expected: &solr.Document{
+				Fields: map[string]interface{}{
+					"id":     "name_s.duravit",
+					"term_s": "dura",
 				},
 			},
 		},
@@ -180,6 +209,22 @@ func TestAddSuggestionTerms(t *testing.T) {
 					},
 				},
 				WeightField:  "project_count_i",
+				SuggestField: "text",
+			},
+			Expected: 3,
+		},
+		TestCase{
+			Collection: new(SuggestionTermCollection),
+			Arguments: &Arguments{
+				Facet: solr.Facet{
+					Name: "name_s",
+					Counts: []solr.FacetCount{
+						solr.FacetCount{Value: "duravit", Count: 1},
+						solr.FacetCount{Value: "toto", Count: 1},
+						solr.FacetCount{Value: "kohler", Count: 1},
+					},
+				},
+				WeightField:  "brand_count_i",
 				SuggestField: "text",
 			},
 			Expected: 3,


### PR DESCRIPTION
PR for DEV-6133:
- Add `facet.mincount` with a default of `1` into the `NewFacetQuery` to fix issue of other types of `name_s` fields besides brands being indexed as suggestion terms
- Adds test cases for brand names 
- Fixes typo in `update_suggestion_terms.go`